### PR TITLE
Post array를 IGListKit에 출력하는 PostVC 추가

### DIFF
--- a/Alala.xcodeproj/project.pbxproj
+++ b/Alala.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		9921706D1F0A374500D03E01 /* SavedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9921706C1F0A374500D03E01 /* SavedViewController.swift */; };
 		992170921F0CA55A00D03E01 /* PostGridCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 992170911F0CA55900D03E01 /* PostGridCell.swift */; };
 		992170941F0E2D0600D03E01 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 992170931F0E2D0600D03E01 /* String.swift */; };
+		992227761F134DB3008DDD59 /* PostViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 992227751F134DB3008DDD59 /* PostViewController.swift */; };
 		99C654E01F0159F30005AD3E /* ArchiveViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C654DF1F0159F30005AD3E /* ArchiveViewController.swift */; };
 		99C654E21F015A310005AD3E /* DiscoverPeopleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C654E11F015A310005AD3E /* DiscoverPeopleViewController.swift */; };
 		99C654E81F015AEC0005AD3E /* FollowViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C654E71F015AEC0005AD3E /* FollowViewController.swift */; };
@@ -161,6 +162,7 @@
 		9921706C1F0A374500D03E01 /* SavedViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SavedViewController.swift; sourceTree = "<group>"; };
 		992170911F0CA55900D03E01 /* PostGridCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostGridCell.swift; sourceTree = "<group>"; };
 		992170931F0E2D0600D03E01 /* String.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
+		992227751F134DB3008DDD59 /* PostViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostViewController.swift; sourceTree = "<group>"; };
 		99C654DF1F0159F30005AD3E /* ArchiveViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArchiveViewController.swift; sourceTree = "<group>"; };
 		99C654E11F015A310005AD3E /* DiscoverPeopleViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiscoverPeopleViewController.swift; sourceTree = "<group>"; };
 		99C654E71F015AEC0005AD3E /* FollowViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FollowViewController.swift; sourceTree = "<group>"; };
@@ -273,6 +275,7 @@
 				99C654F31F03F50A0005AD3E /* OptionsViewController.swift */,
 				9921706A1F0A33ED00D03E01 /* PhotosForYouViewController.swift */,
 				9921706C1F0A374500D03E01 /* SavedViewController.swift */,
+				992227751F134DB3008DDD59 /* PostViewController.swift */,
 			);
 			name = ViewControllers;
 			sourceTree = "<group>";
@@ -623,6 +626,7 @@
 				6F01C2971EF797C400552782 /* UIImageView.swift in Sources */,
 				6F5B85491EE52101009285DD /* FeedViewController.swift in Sources */,
 				9921706D1F0A374500D03E01 /* SavedViewController.swift in Sources */,
+				992227761F134DB3008DDD59 /* PostViewController.swift in Sources */,
 				6FBD85541F04D0E10097B82A /* UserCell.swift in Sources */,
 				9921706B1F0A33ED00D03E01 /* PhotosForYouViewController.swift in Sources */,
 				6F5B85591EE540F9009285DD /* Feed.swift in Sources */,

--- a/Alala/OptionsViewController.swift
+++ b/Alala/OptionsViewController.swift
@@ -23,4 +23,14 @@ class OptionsViewController: UIViewController {
       $0.sizeToFit()
     }
   }
+
+  func logoutButtonDidTap() {
+    AuthService.instance.logout { (success) in
+      if success {
+        NotificationCenter.default.post(name: .presentLogin, object: nil, userInfo: nil)
+      } else {
+
+      }
+    }
+  }
 }

--- a/Alala/PostSectionController.swift
+++ b/Alala/PostSectionController.swift
@@ -23,17 +23,16 @@ class PostSectionController: ListSectionController {
   override func sizeForItem(at index: Int) -> CGSize {
     let width = collectionContext!.containerSize.width
 
-    var multimediaCellRatio = Float(post.multipartIds[0].components(separatedBy: "_")[0])
-
-    if multimediaCellRatio == nil {
-      multimediaCellRatio = 1
+    var multimediaCellRatio: Float = 1.0
+    if post.multipartIds.count > 0 {
+      multimediaCellRatio = Float(post.multipartIds[0].components(separatedBy: "_")[0])!
     }
 
     switch index {
     case 0: // usercell
       return CGSize(width: width, height: 56)
     case 1: // multimediaCell
-      return CGSize(width: width, height: width * CGFloat(multimediaCellRatio!))
+      return CGSize(width: width, height: width * CGFloat(multimediaCellRatio))
     case 2: // buttonGroupcell
       return CGSize(width: width, height: 50)
     case 3: // likeCountCell

--- a/Alala/PostViewController.swift
+++ b/Alala/PostViewController.swift
@@ -1,0 +1,97 @@
+//
+//  PostViewController.swift
+//  Alala
+//
+//  Created by Ellie Kwon on 2017. 7. 10..
+//  Copyright © 2017 team-meteor. All rights reserved.
+//
+
+import UIKit
+import IGListKit
+
+class PostViewController: UIViewController {
+
+  lazy var adapter: ListAdapter = {
+    return ListAdapter(updater: ListAdapterUpdater(), viewController: self)
+  }()
+
+  var posts: [Post] = []
+  fileprivate var nextPage: Int?
+  fileprivate var isLoading: Bool = false
+
+  let collectionView: UICollectionView = {
+    let flowLayout = UICollectionViewFlowLayout()
+    let view = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
+    view.backgroundColor = UIColor.white
+    return view
+  }()
+
+  convenience init() {
+    self.init([])
+  }
+
+  init(_ posts: [Post]) {
+    self.posts = posts
+
+    super.init(nibName: nil, bundle: nil)
+  }
+
+  required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    setupNavigation()
+
+    adapter.collectionView = collectionView
+    adapter.dataSource = self
+    self.view.addSubview(collectionView)
+    collectionView.snp.makeConstraints { (make) in
+      make.top.equalTo(self.view)
+      make.left.equalTo(self.view)
+      make.right.equalTo(self.view)
+      make.bottom.equalTo(self.view)
+    }
+
+    if posts.count > 0 {
+      self.adapter.performUpdates(animated: true, completion: nil)
+    }
+  }
+
+  /**
+   * Setup NavigationItem
+   */
+  func setupNavigation() {
+    let rootVC = self.navigationController?.viewControllers.first
+    if rootVC?.isKind(of: PersonalViewController.self) == true {
+      self.title = "사진"
+    } else {
+      self.title = "둘러보기"
+    }
+  }
+
+  func updateNewPost(_ posts: [Post]) {
+    self.posts = posts
+    self.adapter.performUpdates(animated: true, completion: nil)
+  }
+}
+
+extension PostViewController: ListAdapterDataSource {
+  func objects(for listAdapter: ListAdapter) -> [ListDiffable] {
+    let items: [ListDiffable] = self.posts
+    print("in objects", items)
+    return items
+  }
+  func listAdapter(_ listAdapter: ListAdapter, sectionControllerFor object: Any) -> ListSectionController {
+    if object is Post {
+      return PostSectionController()
+    } else {
+      return ListSectionController()
+    }
+  }
+  func emptyView(for listAdapter: ListAdapter) -> UIView? {
+    return nil
+  }
+}


### PR DESCRIPTION
- Post를 array로 받아서 IGListKit에 출력하는 PostViewController추가
  (내 프로필 화면에서의 list모드, grid모드의 상세보기 두 케이스를 해당 뷰컨으로 공통으로 사용함)
- PersonalViewController의 datasource, delegate를 extention으로 분리
- closed #137, closed #138